### PR TITLE
Replaces react-jss to styled-component and setup i18next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -946,7 +946,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
       "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -6814,6 +6813,14 @@
         }
       }
     },
+    "html-parse-stringify2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
+      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+      "requires": {
+        "void-elements": "^2.0.1"
+      }
+    },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
@@ -6922,6 +6929,22 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "i18next": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.0.0.tgz",
+      "integrity": "sha512-xxNKNOqLdGP/M+/fzzBOhcc9hCAqv6gDhHq0xbYz/Vlz5PlMfr9P1LbBvmk7RkZjYoh/kyM1tnfSl+sJ2VaD0Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
+    "i18next-xhr-backend": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz",
+      "integrity": "sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -11677,6 +11700,15 @@
       "integrity": "sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==",
       "dev": true
     },
+    "react-i18next": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.0.1.tgz",
+      "integrity": "sha512-TazSMob+cEztaaMcX3IQQLltzv4+b3cl6dfs9tUMVj2fD0TRDbTsQ75AaLncw6jqZf08I0yAGHeJnqbBE0eZDw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "html-parse-stringify2": "2.0.1"
+      }
+    },
     "react-is": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
@@ -11849,8 +11881,7 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -14084,6 +14115,11 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
       "dev": true
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -47,7 +46,6 @@
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
       "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
@@ -59,7 +57,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -134,7 +131,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -145,7 +141,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -172,7 +167,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -254,7 +248,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -286,7 +279,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -296,8 +288,7 @@
     "@babel/parser": {
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-      "dev": true
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -964,7 +955,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.6.0",
@@ -975,7 +965,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
       "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.6.3",
@@ -992,7 +981,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
       "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
@@ -1020,6 +1008,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==",
       "dev": true
+    },
+    "@emotion/unitless": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
+      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
     },
     "@hapi/address": {
       "version": "2.1.2",
@@ -1876,7 +1869,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2116,6 +2108,43 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -2288,6 +2317,22 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.4.tgz",
       "integrity": "sha512-S6d+tEzc5Af1tKIMbsf2QirCcPdQ+mKUCY2H1nJj1DyA1ShwpsoxEOAwbWsG5gcXNV/olpvQd9vrUWRx4bnhpw==",
       "dev": true
+    },
+    "babel-plugin-styled-components": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
+      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -2929,6 +2974,11 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -2972,7 +3022,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3752,7 +3801,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3760,8 +3808,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -4129,6 +4176,11 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -4227,6 +4279,16 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
+    },
+    "css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.33",
@@ -4446,7 +4508,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -5051,8 +5112,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.12.0",
@@ -5571,8 +5631,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -6434,8 +6493,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "8.0.2",
@@ -6573,8 +6631,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -7325,6 +7382,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-what": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.3.1.tgz",
+      "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -8609,8 +8671,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -8875,8 +8936,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -9061,6 +9121,11 @@
         }
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -9095,6 +9160,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "merge-anything": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.1.tgz",
+      "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
+      "requires": {
+        "is-what": "^3.3.1"
       }
     },
     "merge-deep": {
@@ -9334,8 +9407,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -11208,8 +11280,7 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "postcss-values-parser": {
       "version": "2.0.1",
@@ -12811,8 +12882,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -13250,6 +13320,41 @@
         }
       }
     },
+    "styled-components": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
+      "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^5.0.0",
+        "merge-anything": "^2.2.4",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.6.0",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz",
+          "integrity": "sha512-6ZODuZSFofbxSbcxwsFz+6ioPjb0ISJRRPLZ+WIbjcU2IMU0Io+RGQjjaTgOvNQl007KICBm7zXQaYQEC1r6Bg==",
+          "requires": {
+            "@emotion/memoize": "0.7.3"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
+          "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
+        }
+      }
+    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -13274,11 +13379,20 @@
         }
       }
     },
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -13502,8 +13616,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "i18next": "^19.0.0",
+    "i18next-xhr-backend": "^3.2.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
+    "react-i18next": "^11.0.1",
     "styled-components": "^4.4.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
     "react-scripts": "3.2.0"
   },
   "dependencies": {
-    "aphrodite": "^2.4.0",
     "axios": "^0.19.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
-    "react-jss": "^10.0.0",
-    "react-sweet-state": "^1.1.1"
+    "styled-components": "^4.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,0 +1,3 @@
+{
+  "byContext": "By context"
+}

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -1,0 +1,3 @@
+{
+  "byContext": "Por contexto"
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,16 @@
-import React, { Component } from 'react';
-import { Provider } from './Context';
-import ExampleComponent from './components/ExampleComponent';
+import React, { Component, Suspense } from "react";
+import { Provider } from "./Context";
+import ExampleComponent from "./components/ExampleComponent";
+import Loading from "./components/Loading";
 
 export default class App extends Component {
   render() {
     return (
-      <Provider>
-        <ExampleComponent />
-      </Provider>
-    )
+      <Suspense fallback={<Loading />}>
+        <Provider>
+          <ExampleComponent />
+        </Provider>
+      </Suspense>
+    );
   }
 }

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,38 +1,47 @@
-import React from 'react';
-import axios from 'axios';
+import React from "react";
+import axios from "axios";
+import { ThemeProvider } from "styled-components";
 
 // Make our initial Context and providing our data with async call
 
 export const Context = React.createContext();
 
 export class Provider extends React.Component {
+  state = {
+    term: "",
+    context: null,
+    status: "initial",
+    theme: {
+      color: "white",
+      paragraph_color: "black"
+    }
+  };
 
-    state = {
-        term: "",
-        context: null,
-        status: "initial",
-        theme_color: "white",
-        paragraph_color: "black"
-    };
+  fetch = async () => {
+    const response = await axios.get(
+      "https://jsonplaceholder.typicode.com/todos/1"
+    );
+    this.setState({
+      status: "done",
+      context: response.data
+    });
+  };
 
-    fetch = async () => {
-        const response = await axios.get("https://jsonplaceholder.typicode.com/todos/1");
-        this.setState({
-            status: "done",
-            context: response.data
-        });
-    };
+  componentDidMount() {
+    this.fetch();
+  }
 
-    componentDidMount() {
-        this.fetch()
+  render() {
+    if (!this.state.context) {
+      return null;
     }
 
-    render() {
-        return (
-            this.state.context !== null &&
-            <Context.Provider value={{ ...this.state }}>
-                {this.props.children}
-            </Context.Provider>
-        );
-    }
+    return (
+      <Context.Provider value={{ ...this.state }}>
+        <ThemeProvider theme={this.state.theme}>
+          {this.props.children}
+        </ThemeProvider>
+      </Context.Provider>
+    );
+  }
 }

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,6 +1,7 @@
 import React from "react";
 import axios from "axios";
 import { ThemeProvider } from "styled-components";
+import i18next from "i18next";
 
 // Make our initial Context and providing our data with async call
 
@@ -21,10 +22,16 @@ export class Provider extends React.Component {
     const response = await axios.get(
       "https://jsonplaceholder.typicode.com/todos/1"
     );
-    this.setState({
-      status: "done",
-      context: response.data
-    });
+
+    this.setState(
+      {
+        status: "done",
+        context: response.data
+      },
+      () => {
+        i18next.changeLanguage("en");
+      }
+    );
   };
 
   componentDidMount() {

--- a/src/components/ExampleComponent.js
+++ b/src/components/ExampleComponent.js
@@ -1,83 +1,107 @@
-import React from 'react';
-import brand from '../mdb.png';
+import React, { useContext } from "react";
+import brand from "../mdb.png";
+import styled from "styled-components";
 
 // Our Context
-import { Context } from '../Context';
-
-// JSS
-import { createUseStyles, createTheming } from 'react-jss'
-
-// Creating a namespaced theming object.
-const theming = createTheming(Context)
-
-// Note that `useTheme` here comes from the `theming` object, NOT from `react-jss` import.
-const { useTheme } = theming;
-
-// Create our style based in the context (CSS in JS)
-const useStyles = createUseStyles(
-    {
-        root: {
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            margin: 'auto',
-            flexDirection: "column",
-            background: ({ theme }) => theme.theme_color,
-            color: ({ theme }) => theme.paragraph_color,
-            width: 960,
-            height: "100vh",
-            '& p': {
-                margin: "2vh 0"
-            },
-            '& img': {
-                width: 150,
-                borderRadius: 40
-            },
-            '& h1': {
-                textTransform: "uppercase", 
-                marginBottom: 0
-            }
-
-
-        }
-    },
-    { theming }
-)
+import { Context } from "../Context";
 
 // Set the component to use in HOC schema
 const Root = ({ children, ...props }) => {
-    const theme = useTheme()
-    const classes = useStyles({ ...props, theme })
+  /* By Consumer we can access the context data without prop drilling  */
+  const data = useContext(Context);
 
-    return (
-        <>
-            {/* By Consumer we can access the context data without prop drilling  */}
-            <Context.Consumer>
-                {(data) => (
-                    <div className={classes.root}>{children}
-                        
-                        <img src={brand} alt="MDB Brand" />
+  return (
+    <Container>
+      {children}
 
-                        <h1>{data.context.title}</h1>
-                        <h3>By context</h3>
+      <img src={brand} alt="MDB Brand" />
 
+      <h1>{data.context.title}</h1>
+      <h3>By context</h3>
 
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin fringilla volutpat eros at fringilla. Sed ut consectetur est. Praesent pellentesque eget augue in sollicitudin. Cras felis massa, elementum quis venenatis in, fermentum quis urna. Vivamus quis pharetra tellus, eget posuere sem. Phasellus facilisis cursus felis, non sagittis metus consectetur nec. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin fringilla
+        volutpat eros at fringilla. Sed ut consectetur est. Praesent
+        pellentesque eget augue in sollicitudin. Cras felis massa, elementum
+        quis venenatis in, fermentum quis urna. Vivamus quis pharetra tellus,
+        eget posuere sem. Phasellus facilisis cursus felis, non sagittis metus
+        consectetur nec. Orci varius natoque penatibus et magnis dis parturient
+        montes, nascetur ridiculus mus.
+      </p>
 
-                        <p>Ut porta justo eu velit luctus accumsan. Integer sit amet lectus at sem posuere fringilla. Ut mollis dui non tincidunt suscipit. Aliquam quis dapibus velit. Morbi vel imperdiet lorem. Integer sodales tortor lacus, at euismod nisl eleifend sit amet. Nam non nibh ante. Vivamus et libero fermentum, molestie dolor vel, maximus justo. Nam non gravida lorem. In posuere at dui in pharetra. Vestibulum sed nisi et ligula posuere laoreet. Sed aliquam molestie risus, vel vehicula mauris ultricies lacinia. Duis fermentum sollicitudin elit id tempor. Sed sed iaculis neque, in fermentum odio. Ut cursus sapien eget maximus euismod.</p>
+      <p>
+        Ut porta justo eu velit luctus accumsan. Integer sit amet lectus at sem
+        posuere fringilla. Ut mollis dui non tincidunt suscipit. Aliquam quis
+        dapibus velit. Morbi vel imperdiet lorem. Integer sodales tortor lacus,
+        at euismod nisl eleifend sit amet. Nam non nibh ante. Vivamus et libero
+        fermentum, molestie dolor vel, maximus justo. Nam non gravida lorem. In
+        posuere at dui in pharetra. Vestibulum sed nisi et ligula posuere
+        laoreet. Sed aliquam molestie risus, vel vehicula mauris ultricies
+        lacinia. Duis fermentum sollicitudin elit id tempor. Sed sed iaculis
+        neque, in fermentum odio. Ut cursus sapien eget maximus euismod.
+      </p>
 
-                        <p>Cras tincidunt libero in tellus viverra, nec egestas nisi semper. Maecenas quis egestas lectus. Mauris eu vehicula massa, vel dictum augue. Morbi nec lectus diam. Curabitur ut elit nec purus viverra suscipit quis vel risus. Donec a viverra nisi, vitae condimentum arcu. Donec eget faucibus justo. Nullam malesuada leo et felis congue, vitae aliquet velit lobortis. Nullam in porta mauris. Integer et facilisis turpis. Nulla sit amet facilisis arcu, non ullamcorper purus. Nulla scelerisque sapien in lacinia rhoncus. In hac habitasse platea dictumst. Duis gravida gravida tellus et sollicitudin. Proin ut iaculis quam. Pellentesque bibendum velit sed congue semper.</p>
+      <p>
+        Cras tincidunt libero in tellus viverra, nec egestas nisi semper.
+        Maecenas quis egestas lectus. Mauris eu vehicula massa, vel dictum
+        augue. Morbi nec lectus diam. Curabitur ut elit nec purus viverra
+        suscipit quis vel risus. Donec a viverra nisi, vitae condimentum arcu.
+        Donec eget faucibus justo. Nullam malesuada leo et felis congue, vitae
+        aliquet velit lobortis. Nullam in porta mauris. Integer et facilisis
+        turpis. Nulla sit amet facilisis arcu, non ullamcorper purus. Nulla
+        scelerisque sapien in lacinia rhoncus. In hac habitasse platea dictumst.
+        Duis gravida gravida tellus et sollicitudin. Proin ut iaculis quam.
+        Pellentesque bibendum velit sed congue semper.
+      </p>
 
-                        <p>Cras dapibus sem at neque elementum, vel facilisis ipsum faucibus. Aenean massa diam, ultricies eu ex quis, viverra ullamcorper nisi. In hac habitasse platea dictumst. Curabitur sollicitudin tristique tortor eget pellentesque. Curabitur aliquam tortor nisi. Duis tellus eros, interdum nec massa ut, mattis ultrices ante. Cras et diam congue velit malesuada rutrum. Suspendisse quis mi eu nulla faucibus tincidunt imperdiet vel sem. Maecenas vitae massa erat. Phasellus vitae egestas ex.</p>
+      <p>
+        Cras dapibus sem at neque elementum, vel facilisis ipsum faucibus.
+        Aenean massa diam, ultricies eu ex quis, viverra ullamcorper nisi. In
+        hac habitasse platea dictumst. Curabitur sollicitudin tristique tortor
+        eget pellentesque. Curabitur aliquam tortor nisi. Duis tellus eros,
+        interdum nec massa ut, mattis ultrices ante. Cras et diam congue velit
+        malesuada rutrum. Suspendisse quis mi eu nulla faucibus tincidunt
+        imperdiet vel sem. Maecenas vitae massa erat. Phasellus vitae egestas
+        ex.
+      </p>
 
-                        <p>Quisque convallis libero et nunc faucibus, nec scelerisque lacus scelerisque. Praesent rhoncus et leo vitae consequat. Suspendisse fermentum varius dui id vehicula. Nulla facilisi. Aliquam erat volutpat. Duis metus ipsum, cursus in massa ut, blandit molestie tellus. Nam porttitor dui non auctor scelerisque. Vestibulum non lacus ac urna ultricies consequat quis vel dui. Duis a vestibulum tortor, at blandit mauris. Nullam sit amet pharetra elit, nec posuere magna.</p>
+      <p>
+        Quisque convallis libero et nunc faucibus, nec scelerisque lacus
+        scelerisque. Praesent rhoncus et leo vitae consequat. Suspendisse
+        fermentum varius dui id vehicula. Nulla facilisi. Aliquam erat volutpat.
+        Duis metus ipsum, cursus in massa ut, blandit molestie tellus. Nam
+        porttitor dui non auctor scelerisque. Vestibulum non lacus ac urna
+        ultricies consequat quis vel dui. Duis a vestibulum tortor, at blandit
+        mauris. Nullam sit amet pharetra elit, nec posuere magna.
+      </p>
+    </Container>
+  );
+};
 
-                    </div>
-                )}
-            </Context.Consumer>
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: auto;
+  flex-direction: column;
+  background: ${({ theme }) => theme.color};
+  color: ${({ theme }) => theme.paragraph_color};
+  width: 960px;
+  height: 100vh;
 
-        </>
-    )
-}
+  & p {
+    margin: 2vh 0;
+  }
+
+  & img {
+    width: 150px;
+    border-radius: 40px;
+  }
+
+  & h1 {
+    text-transform: uppercase;
+    margin-bottom: 0;
+  }
+`;
 
 export default Root;

--- a/src/components/ExampleComponent.js
+++ b/src/components/ExampleComponent.js
@@ -1,12 +1,16 @@
 import React, { useContext } from "react";
 import brand from "../mdb.png";
 import styled from "styled-components";
+import i18next from "i18next";
 
 // Our Context
 import { Context } from "../Context";
+import { useTranslation } from "react-i18next";
 
 // Set the component to use in HOC schema
 const Root = ({ children, ...props }) => {
+  const { t } = useTranslation();
+
   /* By Consumer we can access the context data without prop drilling  */
   const data = useContext(Context);
 
@@ -17,7 +21,7 @@ const Root = ({ children, ...props }) => {
       <img src={brand} alt="MDB Brand" />
 
       <h1>{data.context.title}</h1>
-      <h3>By context</h3>
+      <h3>{t("byContext")}</h3>
 
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin fringilla
@@ -74,6 +78,14 @@ const Root = ({ children, ...props }) => {
         ultricies consequat quis vel dui. Duis a vestibulum tortor, at blandit
         mauris. Nullam sit amet pharetra elit, nec posuere magna.
       </p>
+
+      <select
+        value={i18next.language}
+        onChange={event => i18next.changeLanguage(event.target.value)}
+      >
+        <option value={"en"}>English</option>
+        <option value={"pt-BR"}>Português do Brasil</option>
+      </select>
     </Container>
   );
 };

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Loading = () => {
+  return <div>Loading...</div>;
+};
+
+export default Loading;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom'; 
-import App from './App';
-import * as serviceWorker from './serviceWorker'; 
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
+import "./index.css";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,19 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import "./index.css";
+import i18next from "i18next";
+import XHR from "i18next-xhr-backend";
+import { initReactI18next } from "react-i18next";
+
+// Setup i18next
+i18next
+  .use(XHR)
+  .use(initReactI18next)
+  .init({
+    debug: process.env.NODE_ENV === "development",
+
+    fallbackLng: "en"
+  });
 
 ReactDOM.render(<App />, document.getElementById("root"));
 


### PR DESCRIPTION
This PR aims to resolve two issues:

First, `react-jss` is replaced by `styled-components` (#1).

Second, `i18next` is set up and a language selector is placed to provide an example.

Resolves #1 
Resolves #2